### PR TITLE
max-len and no-undefined

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -127,7 +127,7 @@
     "no-trailing-spaces": 2,
     "no-undef": 2,
     "no-undef-init": 2,
-    "no-undefined": 1,
+    "no-undefined": 0,
     "no-underscore-dangle": 0,
     "no-unreachable": 2,
     "no-unused-expressions": 2,

--- a/eslintrc.json
+++ b/eslintrc.json
@@ -39,7 +39,7 @@
     "indent": [2, 2],
     "key-spacing": [2, {"beforeColon": false, "afterColon": true}],
     "max-depth": 0,
-    "max-len": [1, 90, 8],
+    "max-len": [1, 90, 8, {"ignoreUrls": true}],
     "max-nested-callbacks": [1, 4],
     "max-params": 0,
     "max-statements": 0,


### PR DESCRIPTION
This changes two rules:
- `max-len` will now ignore lines that contain URLs and never warn on them.
- `no-undefined` will no longer warn. Use of `undefined` is now allowed.
