### PR TITLE
use the default parser which support es6 out of the box

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -1,6 +1,9 @@
 {
-  "parser": "babel-eslint",
   "plugins": ["markdown"],
+  "parserOptions": {
+    "sourceType": "module",
+    "impliedStrict": true
+  },
   "env": {
     "commonjs": true,
     "es6": true,


### PR DESCRIPTION
don't force the installation of `babel-eslint` as vanilla `eslint` supports `es6` and `babel-eslint` recommends using that instead.
