### PR TITLE
Turn off wrap-regex

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -154,7 +154,7 @@
     "valid-typeof": "error",
     "vars-on-top": "error",
     "wrap-iife": ["error", "any"],
-    "wrap-regex": "error",
+    "wrap-regex": "off",
     "yoda": ["error", "never"],
     "jsdoc/newline-after-description": "warn",
     "require-jsdoc": ["warn", {


### PR DESCRIPTION
Due to some issue, this rule did not used to be enforced, but will start getting enforced in an eslint update. I have the following reasons to propose disabling this rule:

* It's such a minor point that it doesn't seem worth forcing people to migrate their code to keep their builds passing
* It's a purely subjective style rule, there is no real disadvantage to disabling it.
* Speaking for myself, I find the rule makes code less readable because it increases visual noise, while [the docs](https://eslint.org/docs/rules/wrap-regex) say the intention is to make code more readable. If the majority opinion is opposite to mine, I defer on this point.